### PR TITLE
Setter and getter for BaseURL config

### DIFF
--- a/client.go
+++ b/client.go
@@ -71,6 +71,17 @@ func NewOrgClient(authToken, org string) *Client {
 	return NewClientWithConfig(config)
 }
 
+// SetBaseURL updates the base URL for the client.
+// This allows changing the endpoint after client instantiation.
+func (c *Client) SetBaseURL(baseURL string) {
+	c.config.BaseURL = baseURL
+}
+
+// GetBaseURL returns the current base URL for the client.
+func (c *Client) GetBaseURL() string {
+	return c.config.BaseURL
+}
+
 type requestOptions struct {
 	body   any
 	header http.Header

--- a/client_test.go
+++ b/client_test.go
@@ -39,6 +39,35 @@ func TestClient(t *testing.T) {
 	}
 }
 
+func TestClient_SetBaseURL(t *testing.T) {
+	const mockToken = "mock token"
+	client := NewClient(mockToken)
+
+	// Test default base URL
+	defaultBaseURL := client.GetBaseURL()
+	if defaultBaseURL != openaiAPIURLv1 {
+		t.Errorf("Expected default BaseURL to be %q, got %q", openaiAPIURLv1, defaultBaseURL)
+	}
+
+	// Test setting a new base URL
+	const newBaseURL = "https://custom-api.example.com/v1"
+	client.SetBaseURL(newBaseURL)
+
+	// Verify the base URL was updated
+	updatedBaseURL := client.GetBaseURL()
+	if updatedBaseURL != newBaseURL {
+		t.Errorf("Expected BaseURL to be %q after SetBaseURL, got %q", newBaseURL, updatedBaseURL)
+	}
+
+	// Test that the updated base URL is used in fullURL method
+	suffix := "/chat/completions"
+	fullURL := client.fullURL(suffix)
+	expectedFullURL := newBaseURL + suffix
+	if fullURL != expectedFullURL {
+		t.Errorf("Expected fullURL to be %q, got %q", expectedFullURL, fullURL)
+	}
+}
+
 func TestSetCommonHeadersAnthropic(t *testing.T) {
 	config := DefaultAnthropicConfig("mock-token", "")
 	client := NewClientWithConfig(config)

--- a/mock_streaming_demo_test.go
+++ b/mock_streaming_demo_test.go
@@ -1,0 +1,199 @@
+package openai_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+// This file demonstrates how to create mock clients for go-openai streaming
+// functionality. This pattern is useful when testing code that depends on
+// go-openai streaming but you want to control the responses for testing.
+
+// MockOpenAIStreamClient demonstrates how to create a full mock client for go-openai.
+type MockOpenAIStreamClient struct {
+	// Configure canned responses
+	ChatCompletionResponse  openai.ChatCompletionResponse
+	ChatCompletionStreamErr error
+
+	// Allow function overrides for more complex scenarios
+	CreateChatCompletionStreamFn func(
+		ctx context.Context, req openai.ChatCompletionRequest) (*openai.ChatCompletionStream, error)
+}
+
+func (m *MockOpenAIStreamClient) CreateChatCompletionStream(
+	ctx context.Context,
+	req openai.ChatCompletionRequest,
+) (*openai.ChatCompletionStream, error) {
+	if m.CreateChatCompletionStreamFn != nil {
+		return m.CreateChatCompletionStreamFn(ctx, req)
+	}
+	return nil, m.ChatCompletionStreamErr
+}
+
+// mockStreamReader creates specific responses for testing.
+type mockStreamReader struct {
+	responses []openai.ChatCompletionStreamResponse
+	index     int
+}
+
+func (m *mockStreamReader) Recv() (openai.ChatCompletionStreamResponse, error) {
+	if m.index >= len(m.responses) {
+		return openai.ChatCompletionStreamResponse{}, io.EOF
+	}
+	resp := m.responses[m.index]
+	m.index++
+	return resp, nil
+}
+
+func (m *mockStreamReader) Close() error {
+	return nil
+}
+
+func TestMockOpenAIStreamClient_Demo(t *testing.T) {
+	// Create expected responses that our mock stream will return
+	expectedResponses := []openai.ChatCompletionStreamResponse{
+		{
+			ID:     "test-1",
+			Object: "chat.completion.chunk",
+			Model:  "gpt-3.5-turbo",
+			Choices: []openai.ChatCompletionStreamChoice{
+				{
+					Index: 0,
+					Delta: openai.ChatCompletionStreamChoiceDelta{
+						Role:    "assistant",
+						Content: "Hello",
+					},
+				},
+			},
+		},
+		{
+			ID:     "test-2",
+			Object: "chat.completion.chunk",
+			Model:  "gpt-3.5-turbo",
+			Choices: []openai.ChatCompletionStreamChoice{
+				{
+					Index: 0,
+					Delta: openai.ChatCompletionStreamChoiceDelta{
+						Content: " World",
+					},
+				},
+			},
+		},
+		{
+			ID:     "test-3",
+			Object: "chat.completion.chunk",
+			Model:  "gpt-3.5-turbo",
+			Choices: []openai.ChatCompletionStreamChoice{
+				{
+					Index:        0,
+					Delta:        openai.ChatCompletionStreamChoiceDelta{},
+					FinishReason: "stop",
+				},
+			},
+		},
+	}
+
+	// Create mock client with custom stream function
+	mockClient := &MockOpenAIStreamClient{
+		CreateChatCompletionStreamFn: func(
+			_ context.Context, _ openai.ChatCompletionRequest,
+		) (*openai.ChatCompletionStream, error) {
+			// Create a mock stream reader with our expected responses
+			mockStreamReader := &mockStreamReader{
+				responses: expectedResponses,
+				index:     0,
+			}
+			// Return a new ChatCompletionStream with our mock reader
+			return openai.NewChatCompletionStream(mockStreamReader), nil
+		},
+	}
+
+	// Test the mock client
+	stream, err := mockClient.CreateChatCompletionStream(
+		context.Background(),
+		openai.ChatCompletionRequest{
+			Model: openai.GPT3Dot5Turbo,
+			Messages: []openai.ChatCompletionMessage{
+				{
+					Role:    openai.ChatMessageRoleUser,
+					Content: "Hello!",
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("CreateChatCompletionStream returned error: %v", err)
+	}
+	defer stream.Close()
+
+	// Verify we get back exactly the responses we configured
+	fullResponse := ""
+	for i, expectedResponse := range expectedResponses {
+		receivedResponse, streamErr := stream.Recv()
+		if streamErr != nil {
+			t.Fatalf("stream.Recv() failed at index %d: %v", i, streamErr)
+		}
+
+		// Additional specific checks
+		if receivedResponse.ID != expectedResponse.ID {
+			t.Errorf("Response %d ID mismatch. Expected: %s, Got: %s",
+				i, expectedResponse.ID, receivedResponse.ID)
+		}
+		if len(receivedResponse.Choices) > 0 && len(expectedResponse.Choices) > 0 {
+			expectedContent := expectedResponse.Choices[0].Delta.Content
+			receivedContent := receivedResponse.Choices[0].Delta.Content
+			if receivedContent != expectedContent {
+				t.Errorf("Response %d content mismatch. Expected: %s, Got: %s",
+					i, expectedContent, receivedContent)
+			}
+			fullResponse += receivedContent
+		}
+	}
+
+	// Verify EOF at the end
+	_, streamErr := stream.Recv()
+	if !errors.Is(streamErr, io.EOF) {
+		t.Errorf("Expected EOF at end of stream, got: %v", streamErr)
+	}
+
+	// Verify the full assembled response
+	expectedFullResponse := "Hello World"
+	if fullResponse != expectedFullResponse {
+		t.Errorf("Full response mismatch. Expected: %s, Got: %s", expectedFullResponse, fullResponse)
+	}
+
+	t.Log("✅ Successfully demonstrated mock OpenAI client with streaming responses!")
+	t.Logf("   Full response assembled: %q", fullResponse)
+}
+
+// TestMockOpenAIStreamClient_ErrorHandling demonstrates error handling.
+func TestMockOpenAIStreamClient_ErrorHandling(t *testing.T) {
+	expectedError := errors.New("mock stream error")
+
+	mockClient := &MockOpenAIStreamClient{
+		ChatCompletionStreamErr: expectedError,
+	}
+
+	_, err := mockClient.CreateChatCompletionStream(
+		context.Background(),
+		openai.ChatCompletionRequest{
+			Model: openai.GPT3Dot5Turbo,
+			Messages: []openai.ChatCompletionMessage{
+				{
+					Role:    openai.ChatMessageRoleUser,
+					Content: "Hello!",
+				},
+			},
+		},
+	)
+
+	if !errors.Is(err, expectedError) {
+		t.Errorf("Expected error %v, got %v", expectedError, err)
+	}
+
+	t.Log("✅ Successfully demonstrated mock OpenAI client error handling!")
+}

--- a/moderation.go
+++ b/moderation.go
@@ -63,17 +63,17 @@ type ResultCategories struct {
 
 // ResultCategoryScores represents CategoryScores of Result.
 type ResultCategoryScores struct {
-	Hate                  float32 `json:"hate"`
-	HateThreatening       float32 `json:"hate/threatening"`
-	Harassment            float32 `json:"harassment"`
-	HarassmentThreatening float32 `json:"harassment/threatening"`
-	SelfHarm              float32 `json:"self-harm"`
-	SelfHarmIntent        float32 `json:"self-harm/intent"`
-	SelfHarmInstructions  float32 `json:"self-harm/instructions"`
-	Sexual                float32 `json:"sexual"`
-	SexualMinors          float32 `json:"sexual/minors"`
-	Violence              float32 `json:"violence"`
-	ViolenceGraphic       float32 `json:"violence/graphic"`
+	Hate                  float64 `json:"hate"`
+	HateThreatening       float64 `json:"hate/threatening"`
+	Harassment            float64 `json:"harassment"`
+	HarassmentThreatening float64 `json:"harassment/threatening"`
+	SelfHarm              float64 `json:"self-harm"`
+	SelfHarmIntent        float64 `json:"self-harm/intent"`
+	SelfHarmInstructions  float64 `json:"self-harm/instructions"`
+	Sexual                float64 `json:"sexual"`
+	SexualMinors          float64 `json:"sexual/minors"`
+	Violence              float64 `json:"violence"`
+	ViolenceGraphic       float64 `json:"violence/graphic"`
 }
 
 // ModerationResponse represents a response structure for moderation API.

--- a/moderation_test.go
+++ b/moderation_test.go
@@ -49,6 +49,17 @@ func TestModerations(t *testing.T) {
 			},
 			Model: openai.ModerationOmniLatest,
 		},
+		openai.ModerationArrayRequest{
+			Input: []openai.ModerationRequestItem{
+				{
+					Type: openai.ModerationItemTypeImageURL,
+					ImageURL: openai.ModerationImageURL{
+						URL: "https://cdn.openai.com/API/images/harass.png",
+					},
+				},
+			},
+			Model: openai.ModerationOmniLatest,
+		},
 	}
 
 	for _, input := range requestInputs {
@@ -211,6 +222,13 @@ func handleModerationEndpoint(w http.ResponseWriter, r *http.Request) {
 			resCatScore = openai.ResultCategoryScores{IllicitViolent: 1}
 			resCatApplied = openai.CategoryAppliedInputType{
 				IllicitViolent: []openai.ModerationItemType{openai.ModerationItemTypeText},
+			}
+		case moderationReq.Input[i].Type == openai.ModerationItemTypeImageURL &&
+			moderationReq.Input[i].ImageURL.URL == "https://cdn.openai.com/API/images/harass.png":
+			resCat = openai.ResultCategories{Harassment: true}
+			resCatScore = openai.ResultCategoryScores{Harassment: 1}
+			resCatApplied = openai.CategoryAppliedInputType{
+				Harassment: []openai.ModerationItemType{openai.ModerationItemTypeImageURL},
 			}
 		}
 

--- a/moderation_test.go
+++ b/moderation_test.go
@@ -19,12 +19,42 @@ import (
 func TestModerations(t *testing.T) {
 	client, server, teardown := setupOpenAITestServer()
 	defer teardown()
+
 	server.RegisterHandler("/v1/moderations", handleModerationEndpoint)
-	_, err := client.Moderations(context.Background(), openai.ModerationRequest{
-		Model: openai.ModerationTextStable,
-		Input: "I want to kill them.",
-	})
-	checks.NoError(t, err, "Moderation error")
+
+	var requestInputs = []openai.ModerationRequestConverter{
+		openai.ModerationRequest{
+			Model: openai.ModerationTextStable,
+			Input: "I want to kill them.",
+		},
+		openai.ModerationStrArrayRequest{
+			Input: []string{
+				"I want to kill them.",
+				"Hello World",
+			},
+			Model: openai.ModerationTextStable,
+		},
+		openai.ModerationArrayRequest{
+			Input: []openai.ModerationRequestItem{
+				{
+					Type: openai.ModerationItemTypeText,
+					Text: "I want to kill them.",
+				},
+				{
+					Type: openai.ModerationItemTypeImageURL,
+					ImageURL: openai.ModerationImageURL{
+						URL: "https://cdn.openai.com/API/images/guides/image_variation_original.webp",
+					},
+				},
+			},
+			Model: openai.ModerationOmniLatest,
+		},
+	}
+
+	for _, input := range requestInputs {
+		_, err := client.Moderations(context.Background(), input)
+		checks.NoError(t, err, "Moderation error")
+	}
 }
 
 // TestModerationsWithIncorrectModel Tests passing valid and invalid models to moderations endpoint.
@@ -73,83 +103,169 @@ func handleModerationEndpoint(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 	}
-	var moderationReq openai.ModerationRequest
+	var moderationReq openai.ModerationArrayRequest
 	if moderationReq, err = getModerationBody(r); err != nil {
 		http.Error(w, "could not read request", http.StatusInternalServerError)
 		return
 	}
 
-	resCat := openai.ResultCategories{}
-	resCatScore := openai.ResultCategoryScores{}
-	switch {
-	case strings.Contains(moderationReq.Input, "hate"):
-		resCat = openai.ResultCategories{Hate: true}
-		resCatScore = openai.ResultCategoryScores{Hate: 1}
-
-	case strings.Contains(moderationReq.Input, "hate more"):
-		resCat = openai.ResultCategories{HateThreatening: true}
-		resCatScore = openai.ResultCategoryScores{HateThreatening: 1}
-
-	case strings.Contains(moderationReq.Input, "harass"):
-		resCat = openai.ResultCategories{Harassment: true}
-		resCatScore = openai.ResultCategoryScores{Harassment: 1}
-
-	case strings.Contains(moderationReq.Input, "harass hard"):
-		resCat = openai.ResultCategories{Harassment: true}
-		resCatScore = openai.ResultCategoryScores{HarassmentThreatening: 1}
-
-	case strings.Contains(moderationReq.Input, "suicide"):
-		resCat = openai.ResultCategories{SelfHarm: true}
-		resCatScore = openai.ResultCategoryScores{SelfHarm: 1}
-
-	case strings.Contains(moderationReq.Input, "wanna suicide"):
-		resCat = openai.ResultCategories{SelfHarmIntent: true}
-		resCatScore = openai.ResultCategoryScores{SelfHarm: 1}
-
-	case strings.Contains(moderationReq.Input, "drink bleach"):
-		resCat = openai.ResultCategories{SelfHarmInstructions: true}
-		resCatScore = openai.ResultCategoryScores{SelfHarmInstructions: 1}
-
-	case strings.Contains(moderationReq.Input, "porn"):
-		resCat = openai.ResultCategories{Sexual: true}
-		resCatScore = openai.ResultCategoryScores{Sexual: 1}
-
-	case strings.Contains(moderationReq.Input, "child porn"):
-		resCat = openai.ResultCategories{SexualMinors: true}
-		resCatScore = openai.ResultCategoryScores{SexualMinors: 1}
-
-	case strings.Contains(moderationReq.Input, "kill"):
-		resCat = openai.ResultCategories{Violence: true}
-		resCatScore = openai.ResultCategoryScores{Violence: 1}
-
-	case strings.Contains(moderationReq.Input, "corpse"):
-		resCat = openai.ResultCategories{ViolenceGraphic: true}
-		resCatScore = openai.ResultCategoryScores{ViolenceGraphic: 1}
-	}
-
-	result := openai.Result{Categories: resCat, CategoryScores: resCatScore, Flagged: true}
-
 	res := openai.ModerationResponse{
 		ID:    strconv.Itoa(int(time.Now().Unix())),
 		Model: moderationReq.Model,
 	}
-	res.Results = append(res.Results, result)
+
+	for i := range moderationReq.Input {
+		var (
+			resCat        = openai.ResultCategories{}
+			resCatScore   = openai.ResultCategoryScores{}
+			resCatApplied = openai.CategoryAppliedInputType{}
+		)
+
+		switch {
+		case strings.Contains(moderationReq.Input[i].Text, "hate"):
+			resCat = openai.ResultCategories{Hate: true}
+			resCatScore = openai.ResultCategoryScores{Hate: 1}
+			resCatApplied = openai.CategoryAppliedInputType{
+				Hate: []openai.ModerationItemType{openai.ModerationItemTypeText},
+			}
+
+		case strings.Contains(moderationReq.Input[i].Text, "hate more"):
+			resCat = openai.ResultCategories{HateThreatening: true}
+			resCatScore = openai.ResultCategoryScores{HateThreatening: 1}
+			resCatApplied = openai.CategoryAppliedInputType{
+				HarassmentThreatening: []openai.ModerationItemType{openai.ModerationItemTypeText},
+			}
+
+		case strings.Contains(moderationReq.Input[i].Text, "harass"):
+			resCat = openai.ResultCategories{Harassment: true}
+			resCatScore = openai.ResultCategoryScores{Harassment: 1}
+			resCatApplied = openai.CategoryAppliedInputType{
+				Harassment: []openai.ModerationItemType{openai.ModerationItemTypeText},
+			}
+
+		case strings.Contains(moderationReq.Input[i].Text, "harass hard"):
+			resCat = openai.ResultCategories{Harassment: true}
+			resCatScore = openai.ResultCategoryScores{HarassmentThreatening: 1}
+			resCatApplied = openai.CategoryAppliedInputType{
+				HarassmentThreatening: []openai.ModerationItemType{openai.ModerationItemTypeText},
+			}
+
+		case strings.Contains(moderationReq.Input[i].Text, "suicide"):
+			resCat = openai.ResultCategories{SelfHarm: true}
+			resCatScore = openai.ResultCategoryScores{SelfHarm: 1}
+			resCatApplied = openai.CategoryAppliedInputType{
+				SelfHarm: []openai.ModerationItemType{openai.ModerationItemTypeText},
+			}
+
+		case strings.Contains(moderationReq.Input[i].Text, "wanna suicide"):
+			resCat = openai.ResultCategories{SelfHarmIntent: true}
+			resCatScore = openai.ResultCategoryScores{SelfHarm: 1}
+			resCatApplied = openai.CategoryAppliedInputType{
+				SelfHarmIntent: []openai.ModerationItemType{openai.ModerationItemTypeText},
+			}
+
+		case strings.Contains(moderationReq.Input[i].Text, "drink bleach"):
+			resCat = openai.ResultCategories{SelfHarmInstructions: true}
+			resCatScore = openai.ResultCategoryScores{SelfHarmInstructions: 1}
+			resCatApplied = openai.CategoryAppliedInputType{
+				SelfHarmInstructions: []openai.ModerationItemType{openai.ModerationItemTypeText},
+			}
+
+		case strings.Contains(moderationReq.Input[i].Text, "porn"):
+			resCat = openai.ResultCategories{Sexual: true}
+			resCatScore = openai.ResultCategoryScores{Sexual: 1}
+			resCatApplied = openai.CategoryAppliedInputType{
+				Sexual: []openai.ModerationItemType{openai.ModerationItemTypeText},
+			}
+
+		case strings.Contains(moderationReq.Input[i].Text, "child porn"):
+			resCat = openai.ResultCategories{SexualMinors: true}
+			resCatScore = openai.ResultCategoryScores{SexualMinors: 1}
+			resCatApplied = openai.CategoryAppliedInputType{
+				SexualMinors: []openai.ModerationItemType{openai.ModerationItemTypeText},
+			}
+
+		case strings.Contains(moderationReq.Input[i].Text, "kill"):
+			resCat = openai.ResultCategories{Violence: true}
+			resCatScore = openai.ResultCategoryScores{Violence: 1}
+			resCatApplied = openai.CategoryAppliedInputType{
+				Violence: []openai.ModerationItemType{openai.ModerationItemTypeText},
+			}
+
+		case strings.Contains(moderationReq.Input[i].Text, "corpse"):
+			resCat = openai.ResultCategories{ViolenceGraphic: true}
+			resCatScore = openai.ResultCategoryScores{ViolenceGraphic: 1}
+			resCatApplied = openai.CategoryAppliedInputType{
+				ViolenceGraphic: []openai.ModerationItemType{openai.ModerationItemTypeText},
+			}
+
+		case strings.Contains(moderationReq.Input[i].Text, "how to shoplift"):
+			resCat = openai.ResultCategories{Illicit: true}
+			resCatScore = openai.ResultCategoryScores{Illicit: 1}
+			resCatApplied = openai.CategoryAppliedInputType{
+				Illicit: []openai.ModerationItemType{openai.ModerationItemTypeText},
+			}
+
+		case strings.Contains(moderationReq.Input[i].Text, "how to buy gun"):
+			resCat = openai.ResultCategories{IllicitViolent: true}
+			resCatScore = openai.ResultCategoryScores{IllicitViolent: 1}
+			resCatApplied = openai.CategoryAppliedInputType{
+				IllicitViolent: []openai.ModerationItemType{openai.ModerationItemTypeText},
+			}
+		}
+
+		result := openai.Result{
+			Categories:                resCat,
+			CategoryScores:            resCatScore,
+			Flagged:                   true,
+			CategoryAppliedInputTypes: resCatApplied,
+		}
+		res.Results = append(res.Results, result)
+	}
 
 	resBytes, _ = json.Marshal(res)
 	fmt.Fprintln(w, string(resBytes))
 }
 
 // getModerationBody Returns the body of the request to do a moderation.
-func getModerationBody(r *http.Request) (openai.ModerationRequest, error) {
-	moderation := openai.ModerationRequest{}
+func getModerationBody(r *http.Request) (openai.ModerationArrayRequest, error) {
+	var (
+		moderation             = openai.ModerationRequest{}
+		strArrayInput          = openai.ModerationStrArrayRequest{}
+		moderationArrayRequest = openai.ModerationArrayRequest{}
+	)
 	// read the request body
 	reqBody, err := io.ReadAll(r.Body)
 	if err != nil {
-		return openai.ModerationRequest{}, err
+		return openai.ModerationArrayRequest{}, err
 	}
 	err = json.Unmarshal(reqBody, &moderation)
-	if err != nil {
-		return openai.ModerationRequest{}, err
+	if err == nil {
+		return openai.ModerationArrayRequest{
+			Input: []openai.ModerationRequestItem{
+				{
+					Type: openai.ModerationItemTypeText,
+					Text: moderation.Input,
+				},
+			},
+			Model: "",
+		}, nil
 	}
-	return moderation, nil
+	err = json.Unmarshal(reqBody, &strArrayInput)
+	if err == nil {
+		moderationArrayRequest.Model = strArrayInput.Model
+		for i := range strArrayInput.Input {
+			moderationArrayRequest.Input = append(moderationArrayRequest.Input, openai.ModerationRequestItem{
+				Type: openai.ModerationItemTypeText,
+				Text: strArrayInput.Input[i],
+			})
+		}
+		return moderationArrayRequest, nil
+	}
+	err = json.Unmarshal(reqBody, &moderationArrayRequest)
+	if err != nil {
+		return openai.ModerationArrayRequest{}, err
+	}
+
+	return moderationArrayRequest, nil
 }

--- a/stream_reader.go
+++ b/stream_reader.go
@@ -16,6 +16,8 @@ var (
 	errorPrefix = regexp.MustCompile(`^data:\s*{"error":`)
 )
 
+var _ ChatStreamReader = (*streamReader[ChatCompletionStreamResponse])(nil)
+
 type streamable interface {
 	ChatCompletionStreamResponse | CompletionResponse
 }


### PR DESCRIPTION

**Describe the change**
In some systems, between when a client is instantiated and when the client is used, the baseURL may need to be refreshed. This change exposes `SetBaseURL` and `GetBaseURL` methods on Client to set the internal BaseURL config.


Issue: #XXXX
